### PR TITLE
Multi recipients

### DIFF
--- a/Flash Chat iOS13/AppDelegate.swift
+++ b/Flash Chat iOS13/AppDelegate.swift
@@ -40,29 +40,35 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 		// Use this method to release any resources that were specific to the discarded scenes, as they will not return.
 	}
 	
-	static func checkRecipientRegistrationStatus(_ recipients: [String], inDatabase database: Firestore, completionHandler: @escaping ((_ allRecipientsRegistered: Bool, _ error: Error?) -> Void)) {
+	static func checkRecipientRegistrationStatus(_ recipients: [String], inDatabase database: Firestore, completionHandler: @escaping ((_ allRecipientsRegistered: Bool, _ error: Error?) -> Void)) async {
+		let unregisteredRecipients = await fetchUsers(inDatabase: database, recipients: recipients, completionHandler: completionHandler)
+		if unregisteredRecipients.isEmpty {
+			completionHandler(true, nil)
+		} else {
+			completionHandler(false, nil)
+		}
+	}
+
+	static func fetchUsers(inDatabase database: Firestore, recipients: [String], completionHandler: @escaping ((_ allRecipientsRegistered: Bool, _ error: Error?) -> Void)) async -> [String] {
 		var unregisteredRecipients: [String] = []
 		for recipient in recipients.filter({ recipient in
 			return recipient != Auth.auth().currentUser?.email
 		}) {
 			print(recipient)
-			database.collection(Constants.FStore.usersCollectionName)
-				.whereField(Constants.FStore.emailField, isEqualTo: recipient)
-				.getDocuments { users, error in
-					if let error = error {
-						completionHandler(false, error)
-						return
-					} else if (users?.documents.isEmpty)! {
-						unregisteredRecipients.append(recipient)
-					}
+			// Asynchronously fetch this user from Firebase, and append to unregisteredRecipients if they don't exist.
+			do {
+				let userQuerySnapshot = try await database.collection(Constants.FStore.usersCollectionName)
+					.whereField(Constants.FStore.emailField, isEqualTo: recipient)
+					.getDocuments()
+				if userQuerySnapshot.documents.isEmpty {
+					unregisteredRecipients.append(recipient)
 				}
+			} catch {
+				completionHandler(false, error)
+				return unregisteredRecipients
+			}
 		}
-		print("Unregistered recipients: \(unregisteredRecipients)")
-		if !unregisteredRecipients.isEmpty {
-			completionHandler(false, nil)
-		} else {
-			completionHandler(true, nil)
-		}
+		return unregisteredRecipients
 	}
 	
 	static func showError(_ error: Error, customMessage message: String? = nil, inViewController viewController: UIViewController) {

--- a/Flash Chat iOS13/Controllers/ChatViewController.swift
+++ b/Flash Chat iOS13/Controllers/ChatViewController.swift
@@ -50,9 +50,9 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
 						for doc in snapshotDocuments {
 							let data = doc.data()
 							if let sender = data[Constants.FStore.senderField] as? String,
-							   let recipient = selectedThread?.recipients.last as? String,
+							   let recipients = selectedThread?.recipients as? [String],
 							   let body = data[Constants.FStore.bodyField] as? String {
-								AppDelegate.checkRecipientRegistrationStatus(recipient, inDatabase: database) { [self] registered, error in
+								AppDelegate.checkRecipientRegistrationStatus(recipients, inDatabase: database) { [self] registered, error in
 									if let error = error {
 										AppDelegate.showError(error, inViewController: self)
 									} else {
@@ -64,7 +64,7 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
 											tableView?.scrollToRow(at: indexPath, at: .top, animated: true)
 										}
 										if !registered {
-											let userNotRegistered = UIAlertController(title: "\(recipient) is no longer registered!", message: "This thread is read-only until they re-register.", preferredStyle: .alert)
+											let userNotRegistered = UIAlertController(title: "One or more recipients in this thread are no longer registered!", message: "This thread is read-only until they re-register.", preferredStyle: .alert)
 											let okAction = UIAlertAction(title: "OK", style: .default)
 											userNotRegistered.addAction(okAction)
 											present(userNotRegistered, animated: true)

--- a/Flash Chat iOS13/Controllers/ChatViewController.swift
+++ b/Flash Chat iOS13/Controllers/ChatViewController.swift
@@ -52,24 +52,26 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
 							if let sender = data[Constants.FStore.senderField] as? String,
 							   let recipients = selectedThread?.recipients as? [String],
 							   let body = data[Constants.FStore.bodyField] as? String {
-								AppDelegate.checkRecipientRegistrationStatus(recipients, inDatabase: database) { [self] registered, error in
-									if let error = error {
-										AppDelegate.showError(error, inViewController: self)
-									} else {
-										let newMessage = Message(sender: sender, body: body, idString: doc.documentID)
-										messages.append(newMessage)
-										DispatchQueue.main.async { [self] in
-											let indexPath = IndexPath(row: messages.count - 1, section: 0)
-											tableView?.reloadData()
-											tableView?.scrollToRow(at: indexPath, at: .top, animated: true)
-										}
-										if !registered {
-											let userNotRegistered = UIAlertController(title: "One or more recipients in this thread are no longer registered!", message: "This thread is read-only until they re-register.", preferredStyle: .alert)
-											let okAction = UIAlertAction(title: "OK", style: .default)
-											userNotRegistered.addAction(okAction)
-											present(userNotRegistered, animated: true)
-											messageTextfield?.isEnabled = false
-											sendButton?.isEnabled = false
+								Task {
+									await AppDelegate.checkRecipientRegistrationStatus(recipients, inDatabase: database) { [self] registered, error in
+										if let error = error {
+											AppDelegate.showError(error, inViewController: self)
+										} else {
+											let newMessage = Message(sender: sender, body: body, idString: doc.documentID)
+											messages.append(newMessage)
+											DispatchQueue.main.async { [self] in
+												let indexPath = IndexPath(row: messages.count - 1, section: 0)
+												tableView?.reloadData()
+												tableView?.scrollToRow(at: indexPath, at: .top, animated: true)
+											}
+											if !registered {
+												let userNotRegistered = UIAlertController(title: "One or more recipients in this thread are no longer registered!", message: "This thread is read-only until they re-register.", preferredStyle: .alert)
+												let okAction = UIAlertAction(title: "OK", style: .default)
+												userNotRegistered.addAction(okAction)
+												present(userNotRegistered, animated: true)
+												messageTextfield?.isEnabled = false
+												sendButton?.isEnabled = false
+											}
 										}
 									}
 								}

--- a/Flash Chat iOS13/Controllers/ThreadListViewController.swift
+++ b/Flash Chat iOS13/Controllers/ThreadListViewController.swift
@@ -72,19 +72,13 @@ class ThreadListViewController: UITableViewController {
 	}
 	
 	@IBAction func addThread(_ sender: UIBarButtonItem) {
-		let alert = UIAlertController(title: "New Message", message: "Enter recipient email address", preferredStyle: .alert)
+		let alert = UIAlertController(title: "New Message", message: "Enter recipient email address. To message multiple recipients, enter their email addresses separated by a comma (e.g. email@example.com,email@example.com).", preferredStyle: .alert)
 		var textField = UITextField()
 		let cancelAction = UIAlertAction(title: "Cancel", style: .cancel)
 		let addAction = UIAlertAction(title: "Add", style: .default) { [self] (action) in
-			guard let text = textField.text else { return }
-			if text.contains(" ") {
-				let spacesNotAllowed = UIAlertController(title: "The recipients field can't contain spaces. Please try again with the format \"name@example.com,name@example.com\".", message: nil, preferredStyle: .alert)
-				let okAction = UIAlertAction(title: "OK", style: .default)
-				spacesNotAllowed.addAction(okAction)
-				present(spacesNotAllowed, animated: true)
-			}
+			guard let text = textField.text?.replacingOccurrences(of: " ", with: "") else { return }
 			if let messageSender = Auth.auth().currentUser?.email {
-				var recipients = text.components(separatedBy: ",") 
+				var recipients = text.components(separatedBy: ",")
 				recipients.append(messageSender)
 				Task {
 					await AppDelegate.checkRecipientRegistrationStatus(recipients, inDatabase: database) { [self] registered, error in
@@ -197,7 +191,7 @@ class ThreadListViewController: UITableViewController {
 		recipientsExcludingSender.removeAll { recipient in
 			return recipient == Auth.auth().currentUser?.email
 		}
-		let recipients = recipientsExcludingSender.joined()
+		let recipients = recipientsExcludingSender.joined(separator: ", ")
 		contentConfiguration.text = recipients
 		cell.contentConfiguration = contentConfiguration
 		cell.accessoryType = .disclosureIndicator

--- a/Flash Chat iOS13/Controllers/ThreadListViewController.swift
+++ b/Flash Chat iOS13/Controllers/ThreadListViewController.swift
@@ -76,8 +76,15 @@ class ThreadListViewController: UITableViewController {
 		var textField = UITextField()
 		let cancelAction = UIAlertAction(title: "Cancel", style: .cancel)
 		let addAction = UIAlertAction(title: "Add", style: .default) { [self] (action) in
+			guard let text = textField.text else { return }
+			if text.contains(" ") {
+				let spacesNotAllowed = UIAlertController(title: "The recipients field can't contain spaces. Please try again with the format \"name@example.com,name@example.com\".", message: nil, preferredStyle: .alert)
+				let okAction = UIAlertAction(title: "OK", style: .default)
+				spacesNotAllowed.addAction(okAction)
+				present(spacesNotAllowed, animated: true)
+			}
 			if let messageSender = Auth.auth().currentUser?.email {
-				var recipients = textField.text?.components(separatedBy: ",") ?? [messageSender]
+				var recipients = text.components(separatedBy: ",") 
 				recipients.append(messageSender)
 				Task {
 					await AppDelegate.checkRecipientRegistrationStatus(recipients, inDatabase: database) { [self] registered, error in


### PR DESCRIPTION
Added ability to message multiple users in a single thread.
Registered user checks now wait until the Firebase fetch operation completes on all entered users before the function's completion handler is executed.